### PR TITLE
Add new dual controller core option for games like Night Stalker and AD&D

### DIFF
--- a/src/libretro.c
+++ b/src/libretro.c
@@ -930,6 +930,7 @@ bool paused = false;
 bool keyboardChange = false;
 bool keyboardDown = false;
 int  keyboardState = 0;
+static bool dual_controllers = false;
 
 // at 44.1khz, read 735 samples (44100/60) 
 // at 48khz, read 800 samples (48000/60)
@@ -1029,8 +1030,13 @@ static void update_input(void)
 
 	joypad0[14] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
 	joypad0[15] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
-	joypad0[16] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
-	joypad0[17] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+
+    // If we have enabled the Dual Controller option, the Keypad right stick inputs will come from Controller 2
+    if (!dual_controllers)
+    {
+		joypad0[16] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
+		joypad0[17] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+	}
 
 	/* JoyPad 1 */
 	joypad1[0] = joypad_bits[1] & (1 << RETRO_DEVICE_ID_JOYPAD_UP)     ? 1 : 0;
@@ -1055,8 +1061,18 @@ static void update_input(void)
 
 	joypad1[14] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X);
 	joypad1[15] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y);
-	joypad1[16] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
-	joypad1[17] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+
+	// If we have enabled the Dual Controller option, the right analog will be routed to Controller 1
+	if (!dual_controllers)
+	{
+		joypad1[16] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
+		joypad1[17] = InputState(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+	}
+	else
+	{
+		joypad1[16] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X);
+		joypad1[17] = InputState(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y);
+	}
 }
 
 static void check_variables(bool first_run)
@@ -1089,6 +1105,18 @@ static void check_variables(bool first_run)
 				multi_screen_enabled = 1;
 		}
 	}
+ 
+    // Check if the Dual Controller option should be set
+    var.key   = "dual_controller_enabled";
+    var.value = NULL;
+
+    dual_controllers = false;
+
+    if (Environ(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+    {
+        if (strcmp(var.value, "enabled") == 0)
+            dual_controllers = true;
+    }
 }
 
 void retro_set_environment(retro_environment_t fn)

--- a/src/libretro_core_options.h
+++ b/src/libretro_core_options.h
@@ -79,6 +79,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "right"
    },
    {
+      "dual_controller_enabled",
+      "Enable Dual Controllers",
+      NULL,
+      "Maps the Right Analog Keypad Buttons from Controller 2 to Controller 1 Right Analog. This allows games such as Night Stalker and Tron Deadly Discs to support moving and shooting simultaneously.",
+      NULL,
+      "input",
+      {
+         { "enabled",  "Enabled"  },
+         { "disabled", "Disabled" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "freeintv_multiscreen_overlay",
       "Onscreen Interactive Keypad Overlays (Restart and Touchscreen/Mouse Required)",
       NULL,


### PR DESCRIPTION
With this option enabled the right analog stick on the P1 controller will control the P2 keypad, effectively simulating using 2 controllers simultaneously.

A few games like Night Stalker, Tron Deadly Discs and AD&D Cloudy Mountain benefit so you can shoot without having to stop first.